### PR TITLE
Adjust default MIRI readout to FASTR1

### DIFF
--- a/pancake/io.py
+++ b/pancake/io.py
@@ -231,8 +231,8 @@ def determine_exposure_time(subarray, pattern, groups, integrations):
 	if pattern in miri_readout_patterns:
 		#Must be MIRI
 		nframe =  miri_config_dict['readout_pattern_config'][pattern]['nframe']
-		subarray_frame_time = miri_config_dict['subarray_config']['default'][subarray]['tframe'] 
-		exposure_time = subarray_frame_time * nframe * groups * integrations 
+		subarray_frame_time = miri_config_dict['subarray_config']['default'][subarray]['tframe']
+		exposure_time = subarray_frame_time * nframe * groups * integrations + subarray_frame_time * (integrations-1)
 	elif pattern in nircam_readout_patterns:
 		#Must be NIRCam
 		subarray_frame_time = nircam_config_dict['subarray_config']['default'][subarray]['tframe'] 

--- a/pancake/utilities.py
+++ b/pancake/utilities.py
@@ -776,12 +776,12 @@ def optimise_readout(obs_dict, t_exp, optimise_margin, min_sat=1e-6, max_sat=1, 
             pattern, groups, integrations = best_pattern, best_ngroup, best_nint
 
     elif instrument == 'miri':
-        #MIRI optimisation is relatively straightforward, always use FAST readout pattern, so we just need to find the largest number of 
+        #MIRI optimisation is relatively straightforward, always use FASTR1 readout pattern, so we just need to find the largest number of
         #groups that a) doesn't saturate the detector, and b) is within th margin around the submitted time. 
 
         obs_dict['configuration']['detector']['ngroup'] = 2   #If it saturates in 5 groups, tough to observe
         obs_dict['configuration']['detector']['nint'] = 1
-        obs_dict['configuration']['detector']['readout_pattern'] = 'fast'  
+        obs_dict['configuration']['detector']['readout_pattern'] = 'fastr1'
 
         data = calculate_target(obs_dict)
         sat_frac = data['scalar']['fraction_saturation']
@@ -790,7 +790,7 @@ def optimise_readout(obs_dict, t_exp, optimise_margin, min_sat=1e-6, max_sat=1, 
         if sat_frac > 1:
             #There is saturation, use fastest possible readout pattern and warn user.
             print('WARNING: {:.1f}% saturation detected with the shortest possible readout settings. {} pixels affected.'.format(100*sat_frac, sat_pix))
-            pattern, groups, integrations = 'fast', 2, 1
+            pattern, groups, integrations = 'fastr1', 2, 1
         else:
             #No saturation, optimise readout parameters. 
             max_groups = int(np.floor((max_sat/sat_frac)*2))
@@ -835,7 +835,7 @@ def optimise_readout(obs_dict, t_exp, optimise_margin, min_sat=1e-6, max_sat=1, 
                 raise RuntimeError('Unable to identify optimal readout parameters. Increase "optimise_margin" or manually define readout.')
 
             #Otherwise, the optimisation was succesful 
-            pattern, groups, integrations = 'fast', best_ngroup, best_nint
+            pattern, groups, integrations = 'fastr1', best_ngroup, best_nint
     else:
         raise ValueError('Instrument {} is not supported, please select NIRCam or MIRI'.format(instrument))
 


### PR DESCRIPTION
This pull request includes updates to the exposure time calculation and readout pattern handling for MIRI observations in the `pancake` package. The most significant changes involve refining the exposure time formula and replacing the `fast` readout pattern with `fastr1` for consistency and accuracy.

### Improvements to exposure time calculation:

* [`pancake/io.py`](diffhunk://#diff-823b33650281f7ae8fd146853fe4cb36cf3cdcdf2f18bc34313d6dc365450730L235-R235): Updated the `determine_exposure_time` function to include an additional term in the exposure time formula for MIRI observations, accounting for the frame time of the gaps between integrations.

### Updates to MIRI readout pattern:

* `pancake/utilities.py`:
  - Changed the default MIRI readout pattern from `fast` to `fastr1` in the `optimise_readout` function to align with updated instrument configurations.
  - Updated fallback settings for saturation warnings to use the `fastr1` readout pattern instead of `fast`.
  - Modified the final optimised readout parameters to use `fastr1` instead of `fast` for MIRI.